### PR TITLE
Generic way to register hastebin-like services

### DIFF
--- a/plugins/_used.py
+++ b/plugins/_used.py
@@ -1,37 +1,56 @@
 import functools
+import re
+from urllib.parse import urlparse
 
 import aiohttp
 from discord.ext import commands
 
+
+pastebins = {}
+def pastebin(path_re):
+    def register(func):
+        pastebins[func.__name__.replace('_', '.')] = (func, re.compile(path_re))
+        return func
+    return register
+
+
 def get_raw(link):
     """Returns the url for raw version on a hastebin-like"""
+    address = urlparse(link.strip('<>/'))  # Allow for no-embed links
+    if address.scheme not in ('https', 'http'):
+        raise commands.BadArgument(message=f"Please specify the http scheme to use.")
+    func, regexp = pastebins.get(address.netloc, (None, None))
+    if not func:
+        raise commands.BadArgument(message=f"I only accept links from {', '.join(pastebins)}.")
+    match = regexp.match(address.path)
+    if not match:
+        raise commands.BadArgument(message=f"Wrong URI for {address.netloc}.")
 
-    link = link.strip('<>/') # Allow for no-embed links
+    return func(address, match)
 
-    authorized = (
-        'https://hastebin.com',
-        'https://gist.github.com',
-        'https://gist.githubusercontent.com'
-    )
 
-    if not any([link.startswith(url) for url in authorized]):
-        raise commands.BadArgument(message=f"I only accept links from {', '.join(authorized)}. (Starting with 'http').")
+@pastebin(r'/(raw/(\w+)|(\w+)(\..*)?)')
+def hastebin_com(_address, match):
+    return 'https://hastebin.com/raw/' + (match.group(2) or match.group(3))
 
-    domain = link.split('/')[2]
 
-    if domain == 'hastebin.com':
-        if '/raw/' in link:
-            return link
-        token = link.split('/')[-1]
-        if '.' in token:
-            token = token[:token.rfind('.')] # removes extension
-        return f'https://hastebin.com/raw/{token}'
-    else:
-        # Github uses redirection so raw -> usercontent and no raw -> normal
-        # We still need to ensure we get a raw version after this potential redirection
-        if '/raw' in link:
-            return link
-        return link + '/raw'
+@pastebin(r'/[^/]+/[0-9a-fA-F]{32}/raw/[0-9a-fA-F]{40}/.*')
+def gist_githubusercontent_com(address, _match):
+    return address.geturl()
+
+
+@pastebin(r'/[^/]+/[0-9a-fA-F]{32}(/raw)?(/)?')
+def gist_github_com(address, match):
+    return 'https://gist.github.com{}{}{}'.format(
+        address.path,
+        '' if match.group(2) else '/',
+        '' if match.group(1) else 'raw')
+
+
+@pastebin(r'/(\w{10})(\..*)?')
+def bin_drlazor_be(address, _match):
+    return address.geturl()
+
 
 async def paste(text):
     """Return an online bin of given text"""


### PR DESCRIPTION
The current system becomes more and more complicated as new
services get supported. The `get_raw` function is an all-in-one
function that performs hardcoded site verification and hardcoded
string manipulation (either to extract a token or to sanitize the
uri).

The new system provides a simple decorator to register pastebin
handlers. It uses the function's name as site matching. String
sanitization and token extraction is possible thanks to a regexp
that parse the uri.

The handler registration is done as follow, it takes a site name
and a regexp, it returns an absolute URL with an http(s) scheme.

	@pastebin(regexp)
	def example_com(address, match):
	    return f'https://{address.netloc}/{match.group(0)}'

Where:
* `pastebin` is the decorator
* `regexp` is the regexp used to match the url path
* `example.com` is the domain name to match
* `address` is the complete object returned by `urllib.parse.urlparse`
* `match` is the matched path object