### PR TITLE
Add Rust documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It provides some helpful tools:
   + C++ ([cppreference.com](https://en.cppreference.com/))
   + Haskell ([wiki.haskell.org](https://wiki.haskell.org))
   + Python ([python.org](https://python.org))
+  + Rust ([rust-lang.org](https://rust-lang.org))
 
   </details>
 

--- a/plugins/_doc.py
+++ b/plugins/_doc.py
@@ -120,7 +120,7 @@ async def haskell_doc(ctx, text: str):
             await ctx.send(embed=emb)
 
 async def rust_doc(ctx, text: str):
-    """Filters python.org results based on your query"""
+    """Filters doc.rust-lang.org results based on your query"""
 
     text = text.strip('`')
     if text.startswith("std::"):

--- a/plugins/queries.py
+++ b/plugins/queries.py
@@ -74,7 +74,8 @@ class Coding(commands.Cog):
         'c': _doc.c_doc,
         'cpp': _doc.cpp_doc,
         'haskell': _doc.haskell_doc,
-        'python': _doc.python_doc
+        'python': _doc.python_doc,
+        'rust': _doc.rust_doc
     }
 
     @commands.command(


### PR DESCRIPTION
> More documentations and references to come

Alright, let's do just that!

Add support for the official stable Rust documentation through the [List of all items](https://doc.rust-lang.org/stable/std/all.html) page.