### PR TITLE
Replacing Ineffective ways to get the bot mention

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ extensions = (
 )
 
 def _prefix_callable(bot, message):
-    base = [f'<@!{bot.user.id}> ', f'<@{bot.user.id}> ', bot.config['PREFIX']]
+    base = [bot.user.mention, bot.config['PREFIX']]
     # current = utils.get_guild_attr(message.guild, 'prefix')
     # base.append(current)
     return base

--- a/plugins/background.py
+++ b/plugins/background.py
@@ -29,13 +29,12 @@ class Background(commands.Cog):
                 languages = tuple(sorted(json.loads(await response.text())))
 
                 # Rare reassignments
-                if self.bot.languages != languages:
-                    self.bot.languages = languages
+		self.bot.languages = languages if self.bot.languages != languages else self.bot.languages
 
     @tasks.loop(hours=1)
     async def update_dbl_count(self):
         guildCount = len(self.guilds)
-        usersCount = sum([guild.member_count for guild in self.guilds])
+        usersCount = len([member for member in self.get_all_members()])
 
         lists_payloads = (p for p in [
             {'server_count': guildCount},


### PR DESCRIPTION
`f'{<@!bot.user.id>}'` and `f'{<@bot.user.id>}'` are ineffective ways to get the bot mention use instead `bot.user.mention`